### PR TITLE
Close netcdf dataset after getting its size

### DIFF
--- a/thredds_crawler/crawl.py
+++ b/thredds_crawler/crawl.py
@@ -337,6 +337,7 @@ class LeafDataset(object):
                 for vname in nc.variables:
                     var = nc.variables.get(vname)
                     bites += var.dtype.itemsize * var.size
+                nc.close()
                 return bites * 1e-6  # Megabytes
             except ImportError:
                 logger.error("The python-netcdf4 library is required for computing the size of this dataset.")


### PR DESCRIPTION
Thanks for this cool python library. I looked at alternatives (like siphon) but this one still is the most to the point solution with the features / functions I need.
Hopefully, the fact that there have not been any commits to the master branch the last years is a sign of the reliability of the library and that it just works (and not that it is no longer actively maintained).

When I used it to crawl a larger Thredds server, I noticed that the server at some point returned a `502 Bad Gateway` error. It may be related to the issue I try to address in this PR, that netcdf files are not closed after their size is computed, leaving the server with plenty of open datasets?

Another related question is, if I am not interested in the size of a dataset, but just want to get the URLs opening the dataset and computing it`s size is time spent unneccessary. Would it be acceptable for you to change the default, that the size is only computed on user request? I could have a look at that and make a separate PR...

But if this library is no longer maintained, I would be really happy if you could point me to an alternative library that could be used as a replacement (with the same features)...