### PR TITLE
add GHA test badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # thredds_crawler
 
-[![Build Status](https://travis-ci.org/ioos/thredds_crawler.svg?branch=master)](https://travis-ci.org/ioos/thredds_crawler)
+[![Tests](https://github.com/ioos/thredds_crawler/actions/workflows/tests.yml/badge.svg)](https://github.com/ioos/thredds_crawler/actions/workflows/tests.yml)
 
 A simple crawler/parser for THREDDS catalogs
 


### PR DESCRIPTION
Now that GHA is active we can add the badge in the README.